### PR TITLE
Fix error with if-un/set & >1 same-name params

### DIFF
--- a/content/templates.xqm
+++ b/content/templates.xqm
@@ -472,18 +472,18 @@ declare function templates:each($node as node(), $model as map(*), $from as xs:s
 };
 
 declare function templates:if-parameter-set($node as node(), $model as map(*), $param as xs:string) as node()* {
-    let $param := templates:get-configuration($model, "templates:if-parameter-set")($templates:CONFIG_PARAM_RESOLVER)($param)
+    let $values := templates:get-configuration($model, "templates:if-parameter-set")($templates:CONFIG_PARAM_RESOLVER)($param)
     return
-        if ($param and string-length($param) gt 0) then
+        if (exists($values) and string-length(string-join($values)) gt 0) then
             templates:process($node/node(), $model)
         else
             ()
 };
 
 declare function templates:if-parameter-unset($node as node(), $model as item()*, $param as xs:string) as node()* {
-    let $param := templates:get-configuration($model, "templates:if-parameter-unset")($templates:CONFIG_PARAM_RESOLVER)($param)
+    let $values := templates:get-configuration($model, "templates:if-parameter-unset")($templates:CONFIG_PARAM_RESOLVER)($param)
     return
-        if (not($param) or string-length($param) eq 0) then
+        if (empty($values) or string-length(string-join($values)) eq 0) then
             templates:process($node/node(), $model)
         else
             ()

--- a/test/app/set-unset-params.html
+++ b/test/app/set-unset-params.html
@@ -1,0 +1,13 @@
+<html>
+    <head>
+        <title>Test Set/Unset Parameter</title>
+    </head>
+    <body>
+        <div data-template="templates:if-parameter-set" data-template-param="foo">
+            <p id="set">Param foo is set</p>
+        </div>
+        <div data-template="templates:if-parameter-unset" data-template-param="foo">
+            <p id="unset">Param foo is not set</p>
+        </div>
+    </body>
+</html>

--- a/test/mocha/rest_spec.js
+++ b/test/mocha/rest_spec.js
@@ -124,6 +124,19 @@ describe('Supports form fields', function() {
   });
 });
 
+describe('Supports set and unset param', function() {
+  it('supports set and unset with multiple params of the same name', async function() {
+    const res = await axiosInstance.get('set-unset-params.html?foo=bar&foo=baz'
+    // if URL parameters are supplied via params object, mocha will only send one param 
+    // of a given name, so we must include params in the query string
+    );
+    expect(res.status).to.equal(200);
+    const { window } = new JSDOM(res.data);
+    
+    expect(window.document.querySelector('p#set')).to.exist;
+    });
+});
+
 describe('Fail if template is missing', function() {
   it('fails if template could not be found', function () {
     return axiosInstance.get('template-missing.html')


### PR DESCRIPTION
The templates:if-parameter-set and templates:if-parameter-unset directives will raise an error if the selected parameter returns more than one value. This adds handling for multiple instances of a parameter.

See https://github.com/HistoryAtState/hsg-shell/issues/61.