### PR TITLE
Fix form control: radio button & checkbox inputs

### DIFF
--- a/content/templates.xqm
+++ b/content/templates.xqm
@@ -560,12 +560,16 @@ declare function templates:form-control($node as node(), $model as map(*)) as no
             let $name := $node/@name
             let $value := templates:get-configuration($model, "templates:form-control")($templates:CONFIG_PARAM_RESOLVER)($name)
             return
-                if ($value) then
+                if (exists($value)) then
                     switch ($type)
-                        case "checkbox" case "radio" return
+                        case "checkbox" 
+                        case "radio" return
                             element { node-name($node) } {
                                 $node/@* except $node/@checked,
-                                attribute checked { "checked" },
+                                if ($node/@value = $value or $value = "true") then
+                                    attribute checked { "checked" }
+                                else
+                                    (),
                                 $node/node()
                             }
                         default return

--- a/test/app/forms.html
+++ b/test/app/forms.html
@@ -10,8 +10,10 @@
                 <option>value2</option>
             </select>
             <input type="checkbox" name="param3" data-template="templates:form-control"/>
-            <input type="radio" name="param4" value="radio1" data-template="templates:form-control"/>
-            <input type="radio" name="param4" value="radio2" data-template="templates:form-control"/>
+            <input type="checkbox" name="param4" value="checkbox1" data-template="templates:form-control"/>
+            <input type="checkbox" name="param4" value="checkbox2" data-template="templates:form-control"/>
+            <input type="radio" name="param5" value="radio1" data-template="templates:form-control"/>
+            <input type="radio" name="param5" value="radio2" data-template="templates:form-control"/>
         </form>
     </body>
 </html>

--- a/test/mocha/rest_spec.js
+++ b/test/mocha/rest_spec.js
@@ -108,7 +108,8 @@ describe('Supports form fields', function() {
         param1: 'xxx',
         param2: 'value2',
         param3: true,
-        param4: 'radio2'
+        param4: 'checkbox2',
+        param5: 'radio2'
       }
     });
     expect(res.status).to.equal(200);
@@ -131,6 +132,11 @@ describe('Supports form fields', function() {
     expect(control4).to.have.length(2);
     expect(control4[0].checked).to.be.false;
     expect(control4[1].checked).to.be.true;
+    
+    const control5 = window.document.querySelectorAll('input[name="param5"]');
+    expect(control5).to.have.length(2);
+    expect(control5[0].checked).to.be.false;
+    expect(control5[1].checked).to.be.true;
   });
 });
 


### PR DESCRIPTION
Fixes https://github.com/eXist-db/shared-resources/issues/52

Before this PR, saving the following test query to /db/test/templates-form-control.xq...

```xquery
xquery version "3.1";

declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";

declare boundary-space preserve;

declare option output:method "html5";
declare option output:media-type "text/html";

import module namespace templates="http://exist-db.org/xquery/html-templating" at "templates.xqm";

(: sample HTML taken from https://www.w3schools.com/tags/att_input_type_radio.asp :)

let $content := 
    <html>
        <body>
            <h1>Test</h1>
            <form>
                <input data-template="templates:form-control" type="text" name="foo"/><br/>
                <input data-template="templates:form-control" type="checkbox" id="html" name="fav_language" value="HTML"/>
                <label for="html">HTML</label><br/>
                <input data-template="templates:form-control" type="checkbox" id="css" name="fav_language" value="CSS"/>
                <label for="css">CSS</label><br/>
                <input data-template="templates:form-control" type="checkbox" id="javascript" name="fav_language" value="JavaScript"/>
                <label for="javascript">JavaScript</label><br/>
                <input type="submit"/>
            </form>
        </body>
    </html>
let $resolver := function($functionName as xs:string, $arity as xs:int) {
    try {
        function-lookup(xs:QName($functionName), $arity)
    } catch * {
        ()
    }
}
return 
    templates:apply($content, $resolver, map{})
```

... and calling http://localhost:8080/exist/rest/db/test/templates-form-control.xq?fav_language=HTML would return all checkboxes checked:

> <img width="698" alt="Screen Shot 2021-10-25 at 6 31 51 PM" src="https://user-images.githubusercontent.com/59118/138779862-d4e6e71e-248c-4ea0-ad55-f9a2a8446e84.png">

After this PR, loading the page will return just the "HTML" checkbox checked:

> <img width="163" alt="Screen Shot 2021-10-25 at 6 32 40 PM" src="https://user-images.githubusercontent.com/59118/138779927-3131fa97-4cc7-4c18-8858-fa2f8f5b6095.png">

The fix also works for radio buttons:

> <img width="168" alt="Screen Shot 2021-10-25 at 6 33 42 PM" src="https://user-images.githubusercontent.com/59118/138779999-333f08cc-43f5-4ed7-8654-dcee4df505c7.png">

The PR adds a test for the previously untested scenario where a set of checkbox inputs have a `@value` attribute.