### PR TITLE
[enhancement] allow filtering of templating specific data attributes from output

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,7 +30,8 @@ const connectionOptions = {
 const existClient = createClient(connectionOptions);
 
 const static = [
-    "content/*"
+    "content/*",
+    "test/xqs/*{.xq,.xql}"
 ]
 
 // test application metadata

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 	"license": "LGPL-2.1",
 	"scripts": {
 		"start": "npm install && npm run build",
-		"test": "gulp install:all && mocha test/mocha --recursive --exit",
+		"test": "gulp install:all && mocha test/mocha --recursive --exit && node test/xqs/xqSuite.js",
 		"test:watch": "mocha test/mocha --recursive --watch",
 		"build": "gulp build",
 		"build:all": "gulp build:all"

--- a/test/mocha/rest_spec.js
+++ b/test/mocha/rest_spec.js
@@ -14,58 +14,104 @@ const axiosInstance = axios.create({
   baseURL: app
 });
 
-describe('expand HTML template', function () {
+describe('expand HTML template index.html', function () {
+  let document, res
 
-  it('handles default and static parameters', async function () {
-    const res = await axiosInstance.get('index.html');  
+  before(async function () {
+    res = await axiosInstance.get('index.html');  
+    const {window} = new JSDOM(res.data);
+    document = window.document
+  })
+
+  it('returns status ok', async function () {
     expect(res.status).to.equal(200);
-    const { window } = new JSDOM(res.data);
-
-    // default parameter value applies
-    expect(window.document.querySelector('h1.no-lang')).to.exist;
-    expect(window.document.querySelector('h1.no-lang').innerHTML).to.equal('Welcome');
-    // statically defined parameter
-    expect(window.document.querySelector('h1.static-lang')).to.exist;
-    expect(window.document.querySelector('h1.static-lang').innerHTML).to.equal('Witam');
-
-    expect(window.document.querySelector('.custom').innerHTML).to.equal('Custom model item: xxx');
-
-    expect(window.document.querySelector('.default-param').innerHTML).to.equal('fallback');
+    expect(document).to.be.ok;
   });
 
-  it('request parameter overwrites static default', async function () {
-    const res = await axiosInstance.get('index.html', {
+  it('handles default parameters', async function () {
+    // default parameter value applies
+    expect(document.querySelector('h1.no-lang')).to.exist;
+    expect(document.querySelector('h1.no-lang').innerHTML).to.equal('Welcome');
+  });
+
+  it('handles static parameters', async function () {
+      // statically defined parameter
+    expect(document.querySelector('h1.static-lang')).to.exist;
+    expect(document.querySelector('h1.static-lang').innerHTML).to.equal('Witam');
+  });
+
+  it('handles custom model items', async function () {
+    expect(document.querySelector('.custom').innerHTML).to.equal('Custom model item: xxx');
+  });
+
+  it('handles fallbacks', async function () {
+    expect(document.querySelector('.default-param').innerHTML).to.equal('fallback');
+  });
+});
+
+describe('expand HTML template index.html with language parameter set', function () {
+  let document, res
+
+  before(async function () {
+    res = await axiosInstance.get('index.html', {
       params: {
         language: 'de'
       }
     });
-    expect(res.status).to.equal(200);
     const { window } = new JSDOM(res.data);
+    document = window.document
+  })
 
-    // default parameter value applies
-    expect(window.document.querySelector('h1.no-lang')).to.exist;
-    expect(window.document.querySelector('h1.no-lang').innerHTML).to.equal('Willkommen');
-    // statically defined parameter
-    expect(window.document.querySelector('h1.static-lang')).to.exist;
-    expect(window.document.querySelector('h1.static-lang').innerHTML).to.equal('Willkommen');
+  it('request returns with status 200', async function () {
+    expect(res.status).to.equal(200);
+    expect(document).to.be.ok;
   });
 
-  it('converts parameter types', async function () {
-    const res = await axiosInstance.get('types.html', {
+  it('request parameter overwrites default', async function () {
+    // default parameter value applies
+    expect(document.querySelector('h1.no-lang')).to.exist;
+    expect(document.querySelector('h1.no-lang').innerHTML).to.equal('Willkommen');
+  });
+
+  it('request parameter overwrites static', async function () {
+      // statically defined parameter
+    expect(document.querySelector('h1.static-lang')).to.exist;
+    expect(document.querySelector('h1.static-lang').innerHTML).to.equal('Willkommen');
+  });
+});
+
+describe('expand HTML template types.html', function () {
+  let document, res
+
+  before(async function () {
+    res = await axiosInstance.get('types.html', {
       params: {
         n1: 20,
         n2: 30.25,
         date: '2021-02-07+01:00'
       }
     });
-    expect(res.status).to.equal(200);
     const { window } = new JSDOM(res.data);
-
-    // default parameter value applies
-    expect(window.document.querySelector('p.numbers')).to.exist;
-    expect(window.document.querySelector('p.numbers').innerHTML).to.equal('50.25');
-    expect(window.document.querySelector('p.date').innerHTML).to.equal('7');
+    document = window.document
+  })
+  
+  it('returns with status OK', async function () {
+    expect(res.status).to.equal(200);
+    expect(document).to.be.ok;
   });
+
+  it('converts numbers', async function () {
+    // default parameter value applies
+    expect(document.querySelector('p.numbers')).to.exist;
+    expect(document.querySelector('p.numbers').innerHTML).to.equal('50.25');
+  });
+
+  it('converts dates', async function () {
+    expect(document.querySelector('p.date').innerHTML).to.equal('7');
+  });
+});
+
+describe('expand HTML template types-fail.html', function () {
 
   it('rejects wrong parameter type', function () {
     return axiosInstance.get('types-fail.html', {
@@ -80,6 +126,10 @@ describe('expand HTML template', function () {
         expect(error.response.data).to.contain('templates:TypeError');
       });
   });
+
+});
+
+describe('expand HTML template missing-tmpl.html', function () {
 
   it("reports missing template functions", async function () {
 		return axiosInstance.get("missing-tmpl.html")

--- a/test/xqs/test-runner.xq
+++ b/test/xqs/test-runner.xq
@@ -7,7 +7,7 @@ xquery version "3.1";
  : @see http://www.exist-db.org/exist/apps/doc/xqsuite
  :)
 import module namespace test="http://exist-db.org/xquery/xqsuite" at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
-import module namespace tests="http://exist-db.org//templating/tests" at "test-suite.xql";
+import module namespace tests="http://exist-db.org/templating/tests" at "test-suite.xql";
 
 declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";
 declare option output:method "json";

--- a/test/xqs/test-suite.xql
+++ b/test/xqs/test-suite.xql
@@ -1,21 +1,162 @@
 xquery version "3.1";
 
-(:~ This library module contains XQSuite tests for the templating app.
+(:~
+ : XQSuite tests for the templating library.
  :
  : @author eXist-db Project
  : @version 1.0.0
  : @see http://exist-db.org
  :)
 
-module namespace tests = "http://exist-db.org//templating/tests";
+module namespace tt = "http://exist-db.org/templating/tests";
+
+import module namespace templates="http://exist-db.org/xquery/html-templating";
+
 
 declare namespace test="http://exist-db.org/xquery/xqsuite";
 
+(:~
+ : template with
+ : - calls to functions annotated wit %templates:wrap
+ : - nested template function calls
+ : - and templates:each
+ :)
+declare variable $tt:template :=
+    <html>
+        <body data-template="tt:tf">
+            <ul>
+                <li data-template="templates:each" data-template-from="data" data-template-to="item">
+                    <span data-template="tt:n"></span>
+                </li>
+            </ul>
+        </body>
+    </html>
+;
 
+declare variable $tt:data := 
+    <data>
+        <a n="1" />
+        <a n="3" />
+        <b n="2" />
+        <c n="str" />
+    </data>
+;
+
+(:~
+ : minimum configuration to allow testing in XQSuite
+ : as request:* is not bound to anything in this context
+ :)
+declare variable $tt:config-xqsuite-default := map {
+    $templates:CONFIG_PARAM_RESOLVER : tt:resolver#1
+};
+
+(: templating configuration :)
+declare variable $tt:config-filter := map {
+    $templates:CONFIG_PARAM_RESOLVER : tt:resolver#1,
+    $templates:CONFIG_FILTER_ATTRIBUTES : true()
+};
+
+(: templating configuration :)
+declare variable $tt:config-no-filter := map {
+    $templates:CONFIG_PARAM_RESOLVER : tt:resolver#1,
+    $templates:CONFIG_FILTER_ATTRIBUTES : false()
+};
+
+(: parameters cannot be resolved with default resolver in XQSuite context :)
+declare function tt:resolver ($m) {};
+
+declare function tt:lookup ($fn as xs:string, $arity as xs:integer) as function(*)? {
+    function-lookup(xs:QName($fn), $arity)
+};
+
+(: helper function to test for the existence of data-attributes 
+ : used in templating
+ :)
+declare
+    %private
+function tt:get-template-attribute-values ($xml as node()) {
+    $xml//@*[starts-with(local-name(.), $templates:ATTR_DATA_TEMPLATE)]/string()
+};
+
+(:
+ : ---------------------------
+ : TEMPLATING
+ : --------------------------- 
+ :
+ : templating functions for testing
+ : Since functions annotated with %templates:replace do control the output
+ : they are also in charge with to filter it. This is usually not necessary
+ : as the output does not contain any data-templates-* attributes. 
+ :)
 
 declare
-    %test:name('one-is-one')
-    %test:assertTrue
-    function tests:tautology() {
-        1 = 1
+    %templates:wrap
+function tt:tf ($node as node(), $model as map(*)) {
+    count($model("data")),
+    templates:process($node/node(), $model)
+};
+
+declare
+    %templates:wrap
+function tt:n ($node as node(), $model as map(*)) {
+    $model("item")/@n/string()
+};
+
+(: ---------------------------
+ : TESTS
+ : --------------------------- :)
+
+declare
+    %test:assertEmpty
+function tt:attributes-filtered-c() {
+    templates:apply(
+        $tt:template, tt:lookup#2,
+        map { 'data': $tt:data//c }, 
+        $tt:config-filter
+    )
+    => tt:get-template-attribute-values()
+};
+
+declare
+    %test:assertEmpty
+function tt:attributes-filtered-a() {
+    templates:apply(
+        $tt:template, tt:lookup#2,
+        map { 'data': $tt:data//a }, 
+        $tt:config-filter
+    )
+    => tt:get-template-attribute-values()
+};
+
+declare
+    %test:assertEquals("tt:tf", "templates:each", "data", "item", "tt:n")
+function tt:attributes-unfiltered-c() {
+    templates:apply(
+        $tt:template, tt:lookup#2,
+        map { 'data': $tt:data//c }, 
+        $tt:config-no-filter
+    )
+    => tt:get-template-attribute-values()
+};
+
+declare
+    %test:assertEquals("tt:tf", "templates:each", "data", "item", "tt:n", "templates:each", "data", "item", "tt:n")
+function tt:attributes-unfiltered-a() {
+    templates:apply(
+        $tt:template, tt:lookup#2,
+        map { 'data': $tt:data//a },
+        $tt:config-no-filter
+    )
+    => tt:get-template-attribute-values()
+};
+
+declare
+    %test:assertEquals("tt:tf", "templates:each", "data", "item", "tt:n", "templates:each", "data", "item", "tt:n")
+function tt:attributes-unfiltered-by-default() {
+    templates:apply(
+        $tt:template, tt:lookup#2,
+        map { 'data': $tt:data//a },
+        $tt:config-xqsuite-default
+    )
+    => tt:get-template-attribute-values()
 };

--- a/test/xqs/test-suite.xql
+++ b/test/xqs/test-suite.xql
@@ -23,10 +23,11 @@ declare namespace test="http://exist-db.org/xquery/xqsuite";
  :)
 declare variable $tt:template :=
     <html>
-        <body data-template="tt:tf">
+        <body data-template="tt:tf" class="body" data-extra="7">
             <ul>
-                <li data-template="templates:each" data-template-from="data" data-template-to="item">
-                    <span data-template="tt:n"></span>
+                <li data-template="templates:each" data-template-from="data" data-template-to="item"
+                    data-extra="23" class="item">
+                    <span data-template="tt:n" data-extra="42" class="value"></span>
                 </li>
             </ul>
         </body>
@@ -78,6 +79,18 @@ function tt:get-template-attribute-values ($xml as node()) {
     $xml//@*[starts-with(local-name(.), $templates:ATTR_DATA_TEMPLATE)]/string()
 };
 
+declare
+    %private
+function tt:get-extra-data-attribute-values ($xml as node()) {
+    $xml//@data-extra/string()
+};
+
+declare
+    %private
+function tt:get-class-attribute-values ($xml as node()) {
+    $xml//@class/string()
+};
+
 (:
  : ---------------------------
  : TEMPLATING
@@ -126,6 +139,28 @@ function tt:attributes-filtered-a() {
         $tt:config-filter
     )
     => tt:get-template-attribute-values()
+};
+
+declare
+    %test:assertEquals("7", "23", "42", "23", "42")
+function tt:attributes-filtered-a-extra() {
+    templates:apply(
+        $tt:template, tt:lookup#2,
+        map { 'data': $tt:data//a }, 
+        $tt:config-filter
+    )
+    => tt:get-extra-data-attribute-values()
+};
+
+declare
+    %test:assertEquals("body", "item", "value", "item", "value")
+function tt:attributes-filtered-a-class() {
+    templates:apply(
+        $tt:template, tt:lookup#2,
+        map { 'data': $tt:data//a }, 
+        $tt:config-filter
+    )
+    => tt:get-class-attribute-values()
 };
 
 declare

--- a/test/xqs/test-suite.xql
+++ b/test/xqs/test-suite.xql
@@ -63,7 +63,7 @@ declare variable $tt:config-no-filter := map {
 };
 
 (: parameters cannot be resolved with default resolver in XQSuite context :)
-declare function tt:resolver ($m) {};
+declare function tt:resolver ($m) { () };
 
 declare function tt:lookup ($fn as xs:string, $arity as xs:integer) as function(*)? {
     function-lookup(xs:QName($fn), $arity)

--- a/test/xqs/xqSuite.js
+++ b/test/xqs/xqSuite.js
@@ -3,11 +3,12 @@
 const Mocha = require('mocha')
 const http = require('http')
 const expect = require('chai').expect
+const {version} = require('../../package.json')
 
 // Dynamically generate a mocha testsuite for xqsuite tests. Requires its own process, hence && in package.json
 let Test = Mocha.Test
 
-  let url = 'http://localhost:8080/exist/rest/db/system/repo/templating-1.0.0/test/xqs/test-runner.xq'
+let url = `http://localhost:8080/exist/rest/db/system/repo/templating-${version}/test/xqs/test-runner.xq`
   
 http.get(url, (res) => {
   let data = ''


### PR DESCRIPTION
Setting `$templates:CONFIG_FILTER_ATTRIBUTES` to true in the
configuration map will filter templating specific data attributes from
the output.
The setting is off by default to keep backwards compatibility.

Add working XQSuite tests to ensure this works.

Example:

Default output:

```html
<html>
    <body data-template="tt:tf" class="body" data-extra="7">2
        <ul>
            <li data-template="templates:each" data-template-from="data" data-template-to="item" data-extra="23" class="item">
                <span data-template="tt:n" data-extra="42" class="value">1</span>
            </li>
            <li data-template="templates:each" data-template-from="data" data-template-to="item" data-extra="23" class="item">
                <span data-template="tt:n" data-extra="42" class="value">3</span>
            </li>
        </ul>
    </body>
</html>
```

With filtered attributes:

```html
<html>
    <body class="body" data-extra="7">2
        <ul>
            <li data-extra="23" class="item">
                <span data-extra="42" class="value">1</span>
            </li>
            <li data-extra="23" class="item">
                <span data-extra="42" class="value">3</span>
            </li>
        </ul>
    </body>
</html>
```