### PR TITLE
Fix non spec compliant XQuery

### DIFF
--- a/content/templates.xqm
+++ b/content/templates.xqm
@@ -41,14 +41,14 @@ declare variable $templates:ATTR_DATA_TEMPLATE := "data-template";
  : and return the corresponding function item. The simplest implementation of this function could
  : look like this:
  :
- : <pre>function($functionName as xs:string, $arity as xs:int) { function-lookup(xs:QName($functionName), $arity) }</pre>
+ : <pre>function($functionName as xs:string, $arity as xs:integer) { function-lookup(xs:QName($functionName), $arity) }</pre>
  :
  : @param $content the sequence of nodes which will be processed
  : @param $resolver a function which takes a name and returns a function with that name
  : @param $model a sequence of items which will be passed to all called template functions. Use this to pass
  : information between templating instructions.
 :)
-declare function templates:apply($content as node()+, $resolver as function(xs:string, xs:int) as item()?, $model as map(*)?) {
+declare function templates:apply($content as node()+, $resolver as function(xs:string, xs:integer) as item()?, $model as map(*)?) {
     templates:apply($content, $resolver, $model, ())
 };
 
@@ -58,7 +58,7 @@ declare function templates:apply($content as node()+, $resolver as function(xs:s
  : and return the corresponding function item. The simplest implementation of this function could
  : look like this:
  :
- : <pre>function($functionName as xs:string, $arity as xs:int) { function-lookup(xs:QName($functionName), $arity) }</pre>
+ : <pre>function($functionName as xs:string, $arity as xs:integer) { function-lookup(xs:QName($functionName), $arity) }</pre>
  :
  : @param $content the sequence of nodes which will be processed
  : @param $resolver a function which takes a name and returns a function with that name
@@ -69,7 +69,7 @@ declare function templates:apply($content as node()+, $resolver as function(xs:s
  :  whoose job it is to provide values for templated parameters. The function signature for
  :  the 'parameter value resolver' is f($param-name as xs:string) as item()*
 :)
-declare function templates:apply($content as node()+, $resolver as function(xs:string, xs:int) as item()?, $model as map(*)?,
+declare function templates:apply($content as node()+, $resolver as function(xs:string, xs:integer) as item()?, $model as map(*)?,
     $configuration as map(*)?) {
     let $_model := if (exists($model)) then $model else map {}
     let $configuration :=
@@ -90,7 +90,7 @@ declare function templates:apply($content as node()+, $resolver as function(xs:s
         templates:process($root, $__model)
 };
 
-declare %private function templates:get-default-config($resolver as function(xs:string, xs:int) as item()?) as map(*) {
+declare %private function templates:get-default-config($resolver as function(xs:string, xs:integer) as item()?) as map(*) {
     map {
         $templates:CONFIG_FN_RESOLVER : $resolver,
         $templates:CONFIG_PARAM_RESOLVER : templates:lookup-param-from-restserver#1
@@ -290,12 +290,12 @@ declare %private function templates:arg-from-annotation($var as xs:string, $arg 
         string($value)
 };
 
-declare %private function templates:resolve($func as xs:string, $resolver as function(xs:string, xs:int) as function(*)) {
+declare %private function templates:resolve($func as xs:string, $resolver as function(xs:string, xs:integer) as function(*)) {
     templates:resolve(2, $func, $resolver)
 };
 
-declare %private function templates:resolve($arity as xs:int, $func as xs:string,
-    $resolver as function(xs:string, xs:int) as function(*)) {
+declare %private function templates:resolve($arity as xs:integer, $func as xs:string,
+    $resolver as function(xs:string, xs:integer) as function(*)) {
     let $fn := $resolver($func, $arity)
     return
         if (exists($fn)) then
@@ -342,8 +342,12 @@ declare %private function templates:cast($values as item()*, $targetType as xs:s
             switch ($targetType)
                 case "xs:string" return
                     string($value)
-                case "xs:integer" case "xs:int" case "xs:long" return
+                case "xs:integer"
                     xs:integer($value)
+                case "xs:int"
+		    xs:int($value)
+		case "xs:long"
+		    xs:long($value)
                 case "xs:decimal" return
                     xs:decimal($value)
                 case "xs:float" case "xs:double" return


### PR DESCRIPTION
You cannot supply an xs:integer to an xs:int according to the W3C spec, trying to do so will raise an XPTY0004. This makes the code more spec compliant, and therefore compatible with upcoming eXist-db versions that are more spec compliant. We will need a new release of `templating` published to the Public Repo before we can release the next version of eXist-db.

Without such a fix, Monex 3.0.5 (and also other tools that use `templating`) will see errors like this on newer eXist-db versions:
```
<exception>
<path>/db/apps/monex/modules/view.xql</path>
<message>err:XPTY0004 xs:integer(2) is not a sub-type of xs:int [at line 293, column 23, source: /exist/etc/../data/expathrepo/templating-1.0.4/content/templates.xqm] In function: templates:resolve(xs:int, xs:string, function(*)) [293:5:/exist/etc/../data/expathrepo/templating-1.0.4/content/templates.xqm] templates:resolve(xs:string, function(*)) [186:18:/exist/etc/../data/expathrepo/templating-1.0.4/content/templates.xqm] templates:call(item(), element(), map(*)) [136:36:/exist/etc/../data/expathrepo/templating-1.0.4/content/templates.xqm] templates:process(node()*, map(*)) [132:51:/exist/etc/../data/expathrepo/templating-1.0.4/content/templates.xqm] templates:process(node()*, map(*)) [89:9:/exist/etc/../data/expathrepo/templating-1.0.4/content/templates.xqm] templates:apply(node()+, function(*), map(*)?, map(*)?) [43:5:/exist/etc/../data/expathrepo/templating-1.0.4/content/templates.xqm]</message>
</exception>
```