### PR TITLE
Class syntax

### DIFF
--- a/content/templates.xqm
+++ b/content/templates.xqm
@@ -146,12 +146,19 @@ declare function templates:process($nodes as node()*, $model as map(*)) {
                                 return
                                     templates:call($instruction, $node, $model)
                             else
-                                element { node-name($node) } {
-                                    $node/@*, for $child in $node/node() return templates:process($child, $model)
-                                }
-                    else $node
+                                templates:process-children($node, $model)
+                    else templates:process-children($node, $model)
             default return
                 $node
+};
+
+declare %private function templates:process-children($node as node(), $model as map(*)) {
+    element { node-name($node) } {
+        $node/@*,
+        for $child in $node/node()
+        return
+            templates:process($child, $model)
+    }
 };
 
 declare %private function templates:get-instructions($class as xs:string?) as xs:string* {

--- a/content/templates.xqm
+++ b/content/templates.xqm
@@ -94,6 +94,7 @@ declare function templates:apply($content as node()+, $resolver as function(xs:s
 
 declare %private function templates:get-default-config($resolver as function(xs:string, xs:integer) as item()?) as map(*) {
     map {
+        $templates:CONFIG_USE_CLASS_SYNTAX: $templates:SEARCH_IN_CLASS,
         $templates:CONFIG_FN_RESOLVER : $resolver,
         $templates:CONFIG_PARAM_RESOLVER : templates:lookup-param-from-restserver#1
     }
@@ -138,7 +139,7 @@ declare function templates:process($nodes as node()*, $model as map(*)) {
                 return
                     if ($dataAttr) then
                         templates:call($dataAttr, $node, $model)
-                    else if (($model($templates:CONFIGURATION)($templates:CONFIG_USE_CLASS_SYNTAX), $templates:SEARCH_IN_CLASS)[1]) then
+                    else if ($model?($templates:CONFIGURATION)?($templates:CONFIG_USE_CLASS_SYNTAX)) then
                         let $instructions := templates:get-instructions($node/@class)
                         return
                             if ($instructions) then

--- a/test/app/call-from-class.html
+++ b/test/app/call-from-class.html
@@ -1,0 +1,11 @@
+<html>
+
+<head>
+    <title>Test calling Templates from class</title>
+</head>
+
+<body>
+    <p class="test:print-from-class"></p>
+</body>
+
+</html>

--- a/test/app/modules/view.xql
+++ b/test/app/modules/view.xql
@@ -24,7 +24,7 @@ declare variable $test:app-root :=
         substring-before($modulePath, "/modules")
 ;
 
-declare 
+declare
     %templates:wrap
 function test:init-data($node as node(), $model as map(*)) {
     let $addresses := (
@@ -50,23 +50,23 @@ function test:init-data($node as node(), $model as map(*)) {
     }
 };
 
-declare 
+declare
     %templates:wrap
 function test:print-name($node as node(), $model as map(*)) {
     $model("address")?name
 };
-declare 
+declare
     %templates:wrap
 function test:print-city($node as node(), $model as map(*)) {
     $model("address")?city
 };
-declare 
+declare
     %templates:wrap
 function test:print-street($node as node(), $model as map(*)) {
     $model("address")?street
 };
 
-declare 
+declare
     %templates:wrap
     %templates:default("language", "en")
 function test:hello($node as node(), $model as map(*), $language as xs:string) {
@@ -79,26 +79,26 @@ function test:hello($node as node(), $model as map(*), $language as xs:string) {
             "Welcome"
 };
 
-declare 
+declare
     %templates:wrap
     %templates:default("defaultParam", "fallback")
 function test:default($node as node(), $model as map(*), $defaultParam as xs:string) {
     $defaultParam
 };
 
-declare 
+declare
     %templates:wrap
 function test:numbers($node as node(), $model as map(*), $n1 as xs:integer, $n2 as xs:double) {
     ($n1 treat as xs:integer) + ($n2 treat as xs:double)
 };
 
-declare 
+declare
     %templates:wrap
 function test:date($node as node(), $model as map(*), $date as xs:date) {
     day-from-date($date)
 };
 
-declare 
+declare
     %templates:wrap
 function test:boolean($node as node(), $model as map(*), $boolean as xs:boolean) {
     if ($boolean instance of xs:boolean) then
@@ -111,10 +111,17 @@ declare function test:custom-model($node as node(), $model as map(*)) {
     $model?('my-model-item')
 };
 
+declare
+    %templates:wrap
+function test:print-from-class($node as node(), $model as map(*)) {
+    'print-from-class'
+};
 let $config := map {
     $templates:CONFIG_APP_ROOT : $test:app-root,
-    $templates:CONFIG_STOP_ON_ERROR: true()
+    $templates:CONFIG_STOP_ON_ERROR: true(),
+    $templates:CONFIG_USE_CLASS_SYNTAX: xs:boolean(request:get-parameter('classLookup', $templates:SEARCH_IN_CLASS))
 }
+
 let $lookup := function($name as xs:string, $arity as xs:integer) {
     try {
         function-lookup(xs:QName($name), $arity)

--- a/test/mocha/rest_spec.js
+++ b/test/mocha/rest_spec.js
@@ -343,3 +343,29 @@ describe("Supports resolving app location", function() {
 	  expect(para.innerHTML).to.equal("/exist/404.html#");
   });
 });
+
+describe('Templates can be called from class', function () {
+  it('and will be expanded when $templates:CONFIG_USE_CLASS_SYNTAX is true()', async function () {
+    const res = await axiosInstance.get('call-from-class.html', {
+      params: {
+        classLookup: true,
+      },
+    });
+    expect(res.status).to.equal(200);
+    const { window } = new JSDOM(res.data);
+    expect(window.document.querySelector('p').innerHTML).to.equal(
+      'print-from-class'
+    );
+  });
+
+  it('and will not be expanded when $templates:CONFIG_USE_CLASS_SYNTAX is false()', async function () {
+    const res = await axiosInstance.get('call-from-class.html', {
+      params: {
+        classLookup: false,
+      },
+    });
+    expect(res.status).to.equal(200);
+    const { window } = new JSDOM(res.data);
+    expect(window.document.querySelector('p').innerHTML).to.equal('');
+  });
+});


### PR DESCRIPTION
Adds new configuration option `$templates:CONFIG_USE_CLASS_SYNTAX` which defaults to `true()` to be backwards compatible.
When set to `false()` class attributes are no longer parsed for template functions. This will allow `:` in class names and should also be a little **faster**.

```xquery
import module namespace templates="http://exist-db.org/xquery/html-templating";

declare variable $local:templating-configuration := map {
    $templates:CONFIG_USE_CLASS_SYNTAX : false()
};

declare function local:lookup ($functionName as xs:string, $arity as xs:integer) as function(*)? {
    function-lookup(xs:QName($functionName), $arity)
};

templates:apply(
    request:get-data(),
    local:lookup#2,
    (),
    $local:templating-configuration
)
```

This is a version of #25 without formatting changes in the rest_spec
