### PR TITLE
fix(templating): apply all configuration defaults to custom configs

### DIFF
--- a/content/templates.xqm
+++ b/content/templates.xqm
@@ -76,14 +76,12 @@ declare function templates:apply($content as node()+, $resolver as function(xs:s
     let $_model := if (exists($model)) then $model else map {}
     let $configuration :=
         if (exists($configuration)) then
-            map:merge((
-                $configuration,
-                map:entry($templates:CONFIG_FN_RESOLVER, $resolver),
-                if (map:contains($configuration, $templates:CONFIG_PARAM_RESOLVER)) then
-                    ()
-                else
-                    map:entry($templates:CONFIG_PARAM_RESOLVER, templates:lookup-param-from-restserver#1)
-            ))
+            let $defaults := templates:get-default-config($resolver)
+            return fold-left(map:keys($defaults), $configuration, function ($result, $next-default-key) {
+                if (map:contains($result, $next-default-key)) then $result else (
+                    map:put($result, $next-default-key, $defaults($next-default-key))
+                )
+            })
         else
             templates:get-default-config($resolver)
     let $__model := map:merge(($_model, map:entry($templates:CONFIGURATION, $configuration)))

--- a/test/app/modules/view.xql
+++ b/test/app/modules/view.xql
@@ -116,11 +116,22 @@ declare
 function test:print-from-class($node as node(), $model as map(*)) {
     'print-from-class'
 };
+
 let $config := map {
     $templates:CONFIG_APP_ROOT : $test:app-root,
-    $templates:CONFIG_STOP_ON_ERROR: true(),
-    $templates:CONFIG_USE_CLASS_SYNTAX: xs:boolean(request:get-parameter('classLookup', $templates:SEARCH_IN_CLASS))
+    $templates:CONFIG_STOP_ON_ERROR: true()
 }
+
+(: read request parameter first in order to test three states
+ : true, false and unset / default
+ :)
+let $class-syntax-option := request:get-parameter('classLookup', ())
+let $config-with-class-syntax-maybe-set := 
+    if (empty($class-syntax-option)) then (
+        $config
+    ) else (
+        map:put($config, $templates:CONFIG_USE_CLASS_SYNTAX, xs:boolean($class-syntax-option))
+    )
 
 let $lookup := function($name as xs:string, $arity as xs:integer) {
     try {
@@ -135,4 +146,4 @@ let $lookup := function($name as xs:string, $arity as xs:integer) {
  :)
 let $content := request:get-data()
 return
-    templates:apply($content, $lookup, map { "my-model-item": 'xxx' }, $config)
+    templates:apply($content, $lookup, map { "my-model-item": 'xxx' }, $config-with-class-syntax-maybe-set)

--- a/test/mocha/rest_spec.js
+++ b/test/mocha/rest_spec.js
@@ -345,6 +345,17 @@ describe("Supports resolving app location", function() {
 });
 
 describe('Templates can be called from class', function () {
+  it('and will be expanded when $templates:CONFIG_USE_CLASS_SYNTAX is not set', async function () {
+    const res = await axiosInstance.get('call-from-class.html', {
+      params: {},
+    });
+    expect(res.status).to.equal(200);
+    const { window } = new JSDOM(res.data);
+    expect(window.document.querySelector('p').innerHTML).to.equal(
+      'print-from-class'
+    );
+  });
+
   it('and will be expanded when $templates:CONFIG_USE_CLASS_SYNTAX is true()', async function () {
     const res = await axiosInstance.get('call-from-class.html', {
       params: {


### PR DESCRIPTION
The new setting to allow or disallow the legacy class syntax did not default to "allow" when an application passed in a custom configuration map.

The view module of the test application was also changed that the class syntax option uses the default if not explicitly set via `classLookup` parameter in request.

fixes #33 